### PR TITLE
feat(Issue #15): ajout affichage détaillé des questions sélectionnées

### DIFF
--- a/actions/creerExamen.js
+++ b/actions/creerExamen.js
@@ -212,9 +212,38 @@ export default async function creerExamen(rl = null) {
         }
       }
 
-      console.log(`\nNombre de questions sélectionnées : ${selectedBlocks.length}`);
+      // ✅ CORRECTION Issue #15 - Affichage détaillé de la sélection
+      function displaySelection(blocks) {
+        console.log('\n=== SÉLECTION ACTUELLE ===');
+        console.log(`Total : ${blocks.length}/20 questions\n`);
+        
+        if (blocks.length > 0) {
+          console.log('Questions sélectionnées :');
+          blocks.forEach((block, index) => {
+            try {
+              const parsed = parseGiftQuestion(block);
+              console.log(`${index + 1}. ${parsed.title}`);
+            } catch (e) {
+              console.log(`${index + 1}. [Question non parsable]`);
+            }
+          });
+          console.log('');
+        }
 
-      const finish = await rl.question(`Terminer la création maintenant ? (y=oui, n=continuer) : \n${blue}votre examen doit avoir entre 15 et 20 questions uniques pour être valide${reset} `);
+        if (blocks.length < 15) {
+          console.log(`${colors.red}⚠️  Il manque encore ${15 - blocks.length} question(s) (minimum: 15)${colors.reset}`);
+        } else if (blocks.length > 20) {
+          console.log(`${colors.red}⚠️  Vous avez ${blocks.length - 20} question(s) en trop (maximum: 20)${colors.reset}`);
+        } else {
+          console.log(`${colors.green}✓ Nombre de questions valide !${colors.reset}`);
+        }
+        
+        console.log('==========================\n');
+      }
+
+      displaySelection(selectedBlocks);
+
+      const finish = await rl.question(`Terminer la création maintenant ? (y=oui, n=continuer) : `);
       if (finish.trim().toLowerCase() === 'y') break;
     }
 


### PR DESCRIPTION
**Titre :**

Ajout affichage détaillé des questions sélectionnées (Issue 15)

**Description :**

Resolution de l'issue 15

**Probleme**

Lors de la creation d'un examen, l'utilisateur voyait seulement le nombre total de questions selectionnees sans voir le detail des questions choisies.

**Solution implementee**

Ajout d'une fonction displaySelection() qui affiche:
- La liste complete des titres des questions selectionnees
- Un compteur de progression (X/20)
- Des messages d'avertissement si le nombre est invalide
- Un message de validation si le nombre est correct

**Fichier modifie**

- actions/creerExamen.js (lignes 180-213)

**Tests effectues**

- Test avec 1 question: affichage correct avec avertissement
- Test avec plusieurs questions: liste complete visible
- Test avec 15-20 questions: message de validation affiche

Closes #15